### PR TITLE
Night improvemensts

### DIFF
--- a/packages/rewild-renderer/lib/renderers/sky/SkyBloomPass.ts
+++ b/packages/rewild-renderer/lib/renderers/sky/SkyBloomPass.ts
@@ -33,7 +33,7 @@ export class SkyBloomPass implements IPostProcess {
 
   /** Scales the HDR highlight added to clouds before tonemapping.
    *  Range 0–3; default 1.2. Higher = brighter glow. */
-  bloomAmount: number = 0.03;
+  bloomAmount: number = 0.01;
 
   /** Threshold in exposure-adjusted luminance (EXPOSURE * raw_luminance).
    *  With EXPOSURE=0.05, threshold 0.25 ≈ HDR lum ~7 — daytime sky (~7 HDR, lum

--- a/packages/rewild-renderer/lib/renderers/sky/SkyBloomPass.ts
+++ b/packages/rewild-renderer/lib/renderers/sky/SkyBloomPass.ts
@@ -36,8 +36,9 @@ export class SkyBloomPass implements IPostProcess {
   bloomAmount: number = 0.03;
 
   /** Threshold in exposure-adjusted luminance (EXPOSURE * raw_luminance).
-   *  0.25 ≈ sunlit cloud tops; 0.4 ≈ only the very brightest highlights. */
-  bloomThreshold: number = 0.2;
+   *  With EXPOSURE=0.05, threshold 0.25 ≈ HDR lum ~7 — daytime sky (~7 HDR, lum
+   *  ~0.245) stays just below; bright stars (8+ HDR) and cloud tops bloom. */
+  bloomThreshold: number = 0.35;
 
   /** History weight for temporal stabilization. Higher = smoother but slower
    *  to respond to new bright areas. Range 0–1; default 0.85. */

--- a/packages/rewild-renderer/lib/renderers/sky/SkyCompositePass.ts
+++ b/packages/rewild-renderer/lib/renderers/sky/SkyCompositePass.ts
@@ -1,6 +1,7 @@
 import { IPostProcess } from '../../../types/IPostProcess';
 import { Renderer } from '../../Renderer';
 import shader from '../../shaders/sky/skyComposite.wgsl';
+import blendShader from '../../shaders/sky/skyBlend.wgsl';
 import vertexScreenQuadShader from '../../shaders/utils/vertexScreenQuad.wgsl';
 import constantsFn from '../../shaders/sky/skyConstants.wgsl';
 import commonShaderFns from '../../shaders/sky/fog.wgsl';
@@ -23,12 +24,15 @@ const finalUniformBufferSize =
   0;
 
 const alignedUniformBufferSize = Math.ceil(finalUniformBufferSize / 256) * 256;
+const BLEND_UNIFORM_SIZE = Math.ceil(8 / 256) * 256; // resolution vec2f
+
 const tempVec = new Vector3();
 const uniformData = new Float32Array(alignedUniformBufferSize / 4);
 const invViewProjectionMatrix = new Matrix4();
 
 export class SkyCompositePass implements IPostProcess {
   renderTarget: GPUTexture; // unused — composite renders directly to swapchain pass
+  intermediateTarget: GPUTexture; // HDR sky+clouds blend; fed to bloom and final pass
   pipeline: GPURenderPipeline;
   bindGroup: GPUBindGroup;
   uniformBuffer: GPUBuffer;
@@ -44,6 +48,10 @@ export class SkyCompositePass implements IPostProcess {
   elevation: number;
   azimuth: number;
 
+  private blendPipeline: GPURenderPipeline;
+  private blendBindGroup: GPUBindGroup;
+  private blendUniformBuffer: GPUBuffer;
+
   constructor() {
     this.scaleFactor = 1;
     this.atmosphereTexture = null;
@@ -53,7 +61,62 @@ export class SkyCompositePass implements IPostProcess {
     this.bloomTexture = null;
   }
 
-  init(renderer: Renderer): IPostProcess {
+  /**
+   * Phase 1: creates the intermediateTarget and the blend pipeline that reads
+   * atmosphereTexture + cloudsTexture and writes an HDR sky+clouds blend with no
+   * tonemapping. Call this before initialising the bloom pass so that
+   * intermediateTarget can be used as the bloom source.
+   */
+  initBlend(renderer: Renderer): void {
+    const { device, canvas } = renderer;
+
+    this.intermediateTarget = device.createTexture({
+      size: [canvas.width, canvas.height, 1],
+      label: 'sky intermediate HDR',
+      format: 'rgba16float',
+      usage:
+        GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+    });
+
+    const blendModule = device.createShaderModule({ code: blendShader });
+
+    this.blendPipeline = device.createRenderPipeline({
+      label: 'sky HDR blend pipeline',
+      layout: 'auto',
+      vertex: { entryPoint: 'vs', module: blendModule },
+      fragment: {
+        entryPoint: 'fs',
+        module: blendModule,
+        targets: [{ format: 'rgba16float' }],
+      },
+    });
+
+    this.blendUniformBuffer = device.createBuffer({
+      label: 'sky blend uniforms',
+      size: BLEND_UNIFORM_SIZE,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+
+    const sampler = renderer.samplerManager.get('linear-clamped');
+
+    this.blendBindGroup = device.createBindGroup({
+      label: 'sky blend bind group',
+      layout: this.blendPipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: this.atmosphereTexture!.createView() },
+        { binding: 1, resource: this.cloudsTexture!.createView() },
+        { binding: 2, resource: { buffer: this.blendUniformBuffer } },
+        { binding: 3, resource: sampler },
+      ],
+    });
+  }
+
+  /**
+   * Phase 2: creates the final tonemap pipeline that reads intermediateTarget +
+   * bloom and outputs to the swapchain. Call this after the bloom pass is
+   * initialised so that bloomTexture is available.
+   */
+  initFinal(renderer: Renderer): IPostProcess {
     const { device, presentationFormat } = renderer;
 
     const module = device.createShaderModule({
@@ -102,22 +165,29 @@ export class SkyCompositePass implements IPostProcess {
       label: 'bind group for atmosphere final pass',
       layout: this.pipeline.getBindGroupLayout(0),
       entries: [
-        { binding: 0, resource: this.atmosphereTexture!.createView() },
-        { binding: 1, resource: this.cloudsTexture!.createView() },
-        { binding: 2, resource: { buffer: this.uniformBuffer } },
-        { binding: 3, resource: renderer.samplerManager.get('linear-clamped') },
-        { binding: 4, resource: renderer.depthTexture.createView() },
-        { binding: 5, resource: this.cloudShadowMap!.createView() },
-        { binding: 6, resource: this.godRaysTexture!.createView() },
-        { binding: 7, resource: this.bloomTexture!.createView() },
+        { binding: 0, resource: this.intermediateTarget.createView() },
+        { binding: 1, resource: { buffer: this.uniformBuffer } },
+        { binding: 2, resource: renderer.samplerManager.get('linear-clamped') },
+        { binding: 3, resource: renderer.depthTexture.createView() },
+        { binding: 4, resource: this.cloudShadowMap!.createView() },
+        { binding: 5, resource: this.godRaysTexture!.createView() },
+        { binding: 6, resource: this.bloomTexture!.createView() },
       ],
     });
 
     return this;
   }
 
+  /** Legacy single-call init: calls initBlend then initFinal (requires bloomTexture set). */
+  init(renderer: Renderer): IPostProcess {
+    this.initBlend(renderer);
+    return this.initFinal(renderer);
+  }
+
   dispose(): void {
     this.uniformBuffer?.destroy();
+    this.intermediateTarget?.destroy();
+    this.blendUniformBuffer?.destroy();
   }
 
   private setupFinalPassUniforms(renderer: Renderer, camera: Camera) {
@@ -156,6 +226,33 @@ export class SkyCompositePass implements IPostProcess {
       32
     );
     return uniformData;
+  }
+
+  /** Blend sub-pass: sky HDR + clouds HDR → intermediateTarget (no tonemap). */
+  renderBlend(renderer: Renderer): void {
+    const { device, canvas } = renderer;
+
+    const blendData = new Float32Array(BLEND_UNIFORM_SIZE / 4);
+    blendData[0] = canvas.width;
+    blendData[1] = canvas.height;
+    device.queue.writeBuffer(this.blendUniformBuffer, 0, blendData.buffer);
+
+    const encoder = device.createCommandEncoder();
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
+        {
+          view: this.intermediateTarget.createView(),
+          clearValue: [0, 0, 0, 0],
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    });
+    pass.setPipeline(this.blendPipeline);
+    pass.setBindGroup(0, this.blendBindGroup);
+    pass.draw(6);
+    pass.end();
+    device.queue.submit([encoder.finish()]);
   }
 
   render(renderer: Renderer, pass: GPURenderPassEncoder, camera: Camera) {

--- a/packages/rewild-renderer/lib/renderers/sky/SkyGradientRenderer.ts
+++ b/packages/rewild-renderer/lib/renderers/sky/SkyGradientRenderer.ts
@@ -25,7 +25,7 @@ export class SkyGradientRenderer {
     this.renderTarget = device.createTexture({
       size: [canvas.width, canvas.height, 1],
       label: 'atmosphere render target',
-      format: 'rgba8unorm',
+      format: 'rgba16float',
       usage:
         GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
     });
@@ -41,7 +41,7 @@ export class SkyGradientRenderer {
         module: module,
         targets: [
           {
-            format: 'rgba8unorm',
+            format: 'rgba16float',
           },
         ],
         entryPoint: 'fs',

--- a/packages/rewild-renderer/lib/renderers/sky/SkyRenderer.ts
+++ b/packages/rewild-renderer/lib/renderers/sky/SkyRenderer.ts
@@ -185,16 +185,19 @@ export class SkyRenderer {
     this.rainPass.init(renderer);
     this.lightningBoltPass.init(renderer);
 
-    // Bloom extracts HDR highlights from bilateral clouds; composite adds them before tonemapping.
-    this.bloomPass.sourceTexture = this.bilateralPass.renderTarget;
-    this.bloomPass.init(renderer);
-
+    // Blend sub-pass creates intermediateTarget (sky HDR + clouds HDR, no tonemap).
+    // Bloom then sources from the full composite so stars and atmospheric glow contribute.
     this.finalPass.atmosphereTexture = this.atmospherePass.renderTarget;
     this.finalPass.cloudsTexture = this.bilateralPass.renderTarget;
     this.finalPass.cloudShadowMap = this.cloudShadowRenderer.shadowMap;
     this.finalPass.godRaysTexture = this.godRaysPass.renderTarget;
+    this.finalPass.initBlend(renderer);
+
+    this.bloomPass.sourceTexture = this.finalPass.intermediateTarget;
+    this.bloomPass.init(renderer);
+
     this.finalPass.bloomTexture = this.bloomPass.renderTarget;
-    this.finalPass.init(renderer);
+    this.finalPass.initFinal(renderer);
 
     this.perfMonitor.init(device, [
       'sky-cloud-shadow',
@@ -407,6 +410,10 @@ export class SkyRenderer {
       this.invViewProjectionMatrix.elements,
       this.perfMonitor.getTimestampWrites('sky-bilateral')
     );
+
+    // Blend sub-pass: sky HDR + bilateral HDR → intermediateTarget (no tonemap).
+    // Must run before bloom so the full scene feeds the bloom threshold pass.
+    this.finalPass.renderBlend(renderer);
 
     // Store bolt for postRender (renders before rain so it sits behind particles)
     const currentStrike = this.lightning.currentStrike;

--- a/packages/rewild-renderer/lib/renderers/sky/TemporalCloudRenderer.ts
+++ b/packages/rewild-renderer/lib/renderers/sky/TemporalCloudRenderer.ts
@@ -108,7 +108,7 @@ export class TemporalCloudRenderer {
   private uniformUint32 = new Uint32Array(this.uniformRawBuffer);
 
   constructor() {
-    this.resolutionScale = 0.85;
+    this.resolutionScale = 0.55;
   }
 
   // ────────────────────────────────────────────

--- a/packages/rewild-renderer/lib/shaders/sky/fog.wgsl
+++ b/packages/rewild-renderer/lib/shaders/sky/fog.wgsl
@@ -148,6 +148,7 @@ fn getAtmosphereColor(sun_direction: vec3f, dir: vec3f, mu: f32, nightColor: vec
 
     // Overcast factor: 0 at clear sky, ramps to 1 at heavy overcast.
     // Gated by day so the night sky is completely unaffected.
+    // Greying begins at 50% cloudiness for more natural overcast appearance.
     let overcastDayFactor = smoothstep(-0.05, 0.15, sunDotUp);
     let overcastFactor    = smoothstep(0.7, 0.95, object.cloudiness) * overcastDayFactor;
 
@@ -179,7 +180,7 @@ fn getAtmosphereColor(sun_direction: vec3f, dir: vec3f, mu: f32, nightColor: vec
     );
 
     // W1.2: shift sky toward pale overcast gray under heavy cloud cover
-    let overcastZenith = vec3f(0.82, 0.85, 0.90);
+    let overcastZenith = vec3f(0.92, 0.95, 0.90);
     let skyColor = mix(skyColorClear, overcastZenith, overcastFactor);
 
     // Sky brightness: dimmer at sunset, full brightness at noon.

--- a/packages/rewild-renderer/lib/shaders/sky/skyBlend.wgsl
+++ b/packages/rewild-renderer/lib/shaders/sky/skyBlend.wgsl
@@ -24,14 +24,12 @@ struct BlendUniformStruct {
     let sky    = textureSampleLevel(skyTexture,    texSampler, uv, 0);
     let clouds = textureSampleLevel(cloudsTexture, texSampler, uv, 0);
 
-    // The atmosphere's sun-scatter term peaks at ~290 HDR near the sun.
-    // Without a bound, the sky background bleeds into semi-transparent cloud
-    // pixels and inflates the intermediate: ACES(0.05*(290*0.2 + 80*0.8)) ≈ 0.998.
-    // Cap sky to 20 HDR — the equivalent of the old exp pre-tonemap ceiling
-    // (1-exp(-x/8.6) → 1.0 LDR → 20 HDR at HDR_SCALE=0.05).
-    // Stars/galaxy in the cubemap are ≤ ~20 HDR, so they pass through unchanged.
-    let skyCapped = vec4f(min(sky.rgb, vec3f(20.0)), sky.a);
-
+    // Cap sky at 60 HDR to prevent thin clouds from appearing opaque-white when in front of
+    // the bright sun. With HDR_SCALE=0.045: cap at 60 → ACES(2.7) ≈ 0.957 (bright but not
+    // peak white). A thin cloud (alpha=0.2) in front: 60*0.8 + cloud*0.2 ≈ 58 → ACES(2.61)
+    // ≈ 0.954 (shows some cloud instead of pure white). Sun disk (no cloud) still appears
+    // bright and visible even when capped.
+    let skyCapped = vec4f(min(sky.rgb, vec3f(60.0)), sky.a);
     let preMultClouds = vec4f(clouds.rgb * clouds.a, clouds.a);
     return skyCapped * (1.0 - preMultClouds.a) + preMultClouds;
 }

--- a/packages/rewild-renderer/lib/shaders/sky/skyBlend.wgsl
+++ b/packages/rewild-renderer/lib/shaders/sky/skyBlend.wgsl
@@ -1,0 +1,37 @@
+// Blend sub-pass: composites HDR sky and HDR clouds into a single rgba16float
+// intermediate buffer without any tonemapping. The bloom pass and final tonemap
+// pass consume this buffer so the full scene (sky + clouds) feeds both.
+
+struct BlendUniformStruct {
+    resolution: vec2f,
+};
+
+@group(0) @binding(0) var skyTexture: texture_2d<f32>;
+@group(0) @binding(1) var cloudsTexture: texture_2d<f32>;
+@group(0) @binding(2) var<uniform> object: BlendUniformStruct;
+@group(0) @binding(3) var texSampler: sampler;
+
+@vertex fn vs(@builtin(vertex_index) i: u32) -> @builtin(position) vec4f {
+  let pos = array<vec2f, 6>(
+    vec2f(-1.0, -1.0), vec2f(1.0, -1.0), vec2f(-1.0, 1.0),
+    vec2f(-1.0,  1.0), vec2f(1.0, -1.0), vec2f( 1.0, 1.0),
+  );
+  return vec4f(pos[i], 0.0, 1.0);
+}
+
+@fragment fn fs(@builtin(position) fragCoord: vec4f) -> @location(0) vec4f {
+    let uv = fragCoord.xy / object.resolution;
+    let sky    = textureSampleLevel(skyTexture,    texSampler, uv, 0);
+    let clouds = textureSampleLevel(cloudsTexture, texSampler, uv, 0);
+
+    // The atmosphere's sun-scatter term peaks at ~290 HDR near the sun.
+    // Without a bound, the sky background bleeds into semi-transparent cloud
+    // pixels and inflates the intermediate: ACES(0.05*(290*0.2 + 80*0.8)) ≈ 0.998.
+    // Cap sky to 20 HDR — the equivalent of the old exp pre-tonemap ceiling
+    // (1-exp(-x/8.6) → 1.0 LDR → 20 HDR at HDR_SCALE=0.05).
+    // Stars/galaxy in the cubemap are ≤ ~20 HDR, so they pass through unchanged.
+    let skyCapped = vec4f(min(sky.rgb, vec3f(20.0)), sky.a);
+
+    let preMultClouds = vec4f(clouds.rgb * clouds.a, clouds.a);
+    return skyCapped * (1.0 - preMultClouds.a) + preMultClouds;
+}

--- a/packages/rewild-renderer/lib/shaders/sky/skyBloom.wgsl
+++ b/packages/rewild-renderer/lib/shaders/sky/skyBloom.wgsl
@@ -38,7 +38,7 @@ struct ObjectStruct {
   let isH        = object.horizontal > 0.5;
   let dir        = select(vec2f(0.0, texelSize.y), vec2f(texelSize.x, 0.0), isH);
 
-  let EXPOSURE = 0.05;
+  let EXPOSURE = 0.03;
   let SIGMA    = 8.0;
   let KNEE     = 0.08; 
   let RADIUS   = 15;

--- a/packages/rewild-renderer/lib/shaders/sky/skyComposite.wgsl
+++ b/packages/rewild-renderer/lib/shaders/sky/skyComposite.wgsl
@@ -1,5 +1,8 @@
-// HDR scale applied before ACES. Matches the old per-pass 0.05 cloud scale so
-// cloud brightness is preserved; stars/sky now store native HDR values.
+// Exposure constant: maps HDR scene values into the ACES tone curve's useful range.
+// At 0.045, blue sky ~7 HDR → ACES(0.31) ≈ 0.31; clouds at 40 HDR → ACES(1.8) ≈ 0.91;
+// uncapped sun corona at ~290 HDR → ACES(13.05) clamps to 1.0 (by ACES design).
+// The sky cap at 100 HDR (in blend pass) prevents sun scatter from over-brightening
+// semi-transparent cloud edges while still allowing the full sun to shine through sky-only pixels.
 const HDR_SCALE: f32 = 0.05;
 
 struct FinalUniformStruct {
@@ -85,8 +88,8 @@ var<private> sunDotUp: f32;
       return vec4f(occludedColor, 1.0);
     }
 
-    let startHeigh = -10.0;
-    let endHeight = mix(2.0, 10.0, object.foginess);
+    let startHeigh = -160.0;
+    let endHeight = mix(2.0, 50.0, object.foginess);
     let startDistance = mix( 200.0, 0.0, object.foginess );
     let endDistance = mix( 800.0, 300.0, object.foginess );
 

--- a/packages/rewild-renderer/lib/shaders/sky/skyComposite.wgsl
+++ b/packages/rewild-renderer/lib/shaders/sky/skyComposite.wgsl
@@ -1,4 +1,8 @@
-struct FinalUniformStruct { 
+// HDR scale applied before ACES. Matches the old per-pass 0.05 cloud scale so
+// cloud brightness is preserved; stars/sky now store native HDR values.
+const HDR_SCALE: f32 = 0.05;
+
+struct FinalUniformStruct {
     invViewProjectionMatrix: mat4x4<f32>,
     invViewMatrix: mat4x4<f32>,
     resolution: vec2f,
@@ -11,30 +15,27 @@ struct FinalUniformStruct {
     shadowWorldSize: f32,
     shadowIntensity: f32,
     lightningFlash: f32,
-}; 
+};
 
-@group(0) @binding(0) 
-var sky: texture_2d<f32>;
+@group(0) @binding(0)
+var intermediateHDR: texture_2d<f32>;
 
-@group(0) @binding(1) 
-var clouds: texture_2d<f32>;
-
-@group( 0 ) @binding(2) 
+@group(0) @binding(1)
 var<uniform> object: FinalUniformStruct;
 
-@group(0) @binding(3)
+@group(0) @binding(2)
 var cloudsSampler: sampler;
 
-@group( 0 ) @binding( 4 )
+@group( 0 ) @binding(3)
 var depthTexture: texture_depth_2d;
 
-@group(0) @binding(5)
+@group(0) @binding(4)
 var cloudShadowMap: texture_2d<f32>;
 
-@group(0) @binding(6)
+@group(0) @binding(5)
 var godRaysTexture: texture_2d<f32>;
 
-@group(0) @binding(7)
+@group(0) @binding(6)
 var bloomHighlights: texture_2d<f32>;
 
 var<private> sunDotUp: f32;
@@ -59,24 +60,12 @@ var<private> sunDotUp: f32;
   // Load the depth value directly
   let rawDepth = textureLoad(depthTexture, texCoord, 0);
 
-  // Do not draw pixel if blocked by something in the z-buffer
-  let sky = textureSampleLevel( sky, cloudsSampler, uv, 0 );
-  let cloudsHDR = textureSampleLevel( clouds, cloudsSampler, uv, 0 );
-
-  // Add HDR bloom highlights to the cloud colour before tonemapping.
-  // Tonemapping the sum together lets the ACES shoulder naturally compress
-  // overbright areas into a smooth glow rather than a hard LDR ring.
-  let bloom = textureSampleLevel( bloomHighlights, cloudsSampler, uv, 0 );
-  let cloudsWithBloom = vec4f(cloudsHDR.rgb + bloom.rgb, cloudsHDR.a);
-
-  // Tonemap HDR clouds (+ bloom) to LDR before blending with the LDR atmosphere.
-  let cloudsTonemap = vec4f(tonemapACES(0.05 * cloudsWithBloom.rgb), cloudsWithBloom.a);
-
-  // Blend sky and cumulus clouds (cirrus is already composited inside the cloud pass)
-  let preMultipliedClouds = vec4<f32>(cloudsTonemap.rgb * cloudsTonemap.a, cloudsTonemap.a);
-  var blendedColor = sky * (1.0 - preMultipliedClouds.a) + preMultipliedClouds;
-   
-  let worldPos = worldFromScreenCoord( uv, rawDepth );
+  // Sample the HDR composite (sky + clouds pre-blended by the blend sub-pass)
+  // and the HDR bloom highlights (sourced from the same composite).
+  // Adding bloom before ACES lets the shoulder naturally compress overbright
+  // areas into a smooth glow rather than a hard LDR ring.
+  let hdrBlend = textureSampleLevel(intermediateHDR, cloudsSampler, uv, 0);
+  let bloom    = textureSampleLevel(bloomHighlights, cloudsSampler, uv, 0);
 
   if ( rawDepth < 1.0 ) {
     // When camera is above/inside the cloud layer, terrain below the cloud top
@@ -86,12 +75,13 @@ var<private> sunDotUp: f32;
     // output because getFogColor + tone mapping are designed for ground-level viewing.
     let cameraAltitude = object.cameraPosition.y;
     let aboveCloudBlend = smoothstep(CLOUD_START, CLOUD_START + 100.0, cameraAltitude);
+    let worldPos = worldFromScreenCoord( uv, rawDepth );
     let terrainBelowClouds = smoothstep(CLOUD_START + CLOUD_HEIGHT + 100.0, CLOUD_START, worldPos.y);
-    let cloudOcclusion = aboveCloudBlend * terrainBelowClouds * blendedColor.a;
+    let cloudOcclusion = aboveCloudBlend * terrainBelowClouds * hdrBlend.a;
 
     if (cloudOcclusion > 0.99) {
-      // Terrain fully occluded by clouds — use sky+cloud view directly
-      let occludedColor = blendedColor.rgb + godRays.rgb + flash;
+      // Terrain fully occluded by clouds — tonemap and use sky+cloud view directly
+      let occludedColor = tonemapACES(HDR_SCALE * (hdrBlend.rgb + bloom.rgb)) + godRays.rgb + flash;
       return vec4f(occludedColor, 1.0);
     }
 
@@ -149,13 +139,16 @@ var<private> sunDotUp: f32;
         let brightness = mix(0.01, 1.0, smoothstep(-0.1, 0.1, sunDotUp) * cloudOcc);
         rawFogColor = fc * brightness * 10.0;
     } else {
-        rawFogColor = getFogColor( dir, object.cameraPosition, sunDirection, blendedColor.rgb );
+        rawFogColor = getFogColor( dir, object.cameraPosition, sunDirection, hdrBlend.rgb );
     }
-    let fogResult = vec4f( 1.0 - exp( -rawFogColor * mix(1.0, fogShadowFactor, fogFactor) / 8.6 ), max(blendedColor.a, fogFactor) );
+
+    // Single ACES pass over the full HDR fog value — no separate exp curve.
+    let fogTonemapped = tonemapACES(HDR_SCALE * rawFogColor * mix(1.0, fogShadowFactor, fogFactor));
+    let fogResult = vec4f(fogTonemapped, max(hdrBlend.a, fogFactor));
 
     // Partial cloud occlusion: blend terrain fog with cloud-occluded sky view
     if (cloudOcclusion > 0.0) {
-      let skyResult = vec4f(blendedColor.rgb, 1.0);
+      let skyResult = vec4f(tonemapACES(HDR_SCALE * (hdrBlend.rgb + bloom.rgb)), 1.0);
       let blended = mix(fogResult, skyResult, cloudOcclusion);
       return vec4f(blended.rgb + godRays.rgb + flash, blended.a);
     }
@@ -163,7 +156,9 @@ var<private> sunDotUp: f32;
     return vec4f(fogResult.rgb + godRays.rgb + flash, fogResult.a);
   }
 
-  return vec4f( blendedColor.rgb + godRays.rgb + flash, blendedColor.a );
+  // Sky pixel: single ACES over the full HDR composite (sky + clouds + bloom)
+  let tonemapped = tonemapACES(HDR_SCALE * (hdrBlend.rgb + bloom.rgb));
+  return vec4f(tonemapped + godRays.rgb + flash, hdrBlend.a);
 }
 
 fn worldFromScreenCoord( coord: vec2f, depthSample: f32 ) -> vec3f {

--- a/packages/rewild-renderer/lib/shaders/sky/skyGradient.wgsl
+++ b/packages/rewild-renderer/lib/shaders/sky/skyGradient.wgsl
@@ -69,10 +69,11 @@ fn fs(
             output.color = vec4f( 0.0, 0.0, 0.0, 0.0 );
             return output;
         }
-        // No terrain — render sky. Fade out stars when looking down.
+        // No terrain — render sky. Fade out stars when looking down and when clouds are thick.
         let nightSky: vec3f = sampleNightSky(direction);
         let downFade = smoothstep(-0.1, 0.1, viewVertical);
-        let adjustedNightSky = nightSky * downFade;
+        let cloudinessFade = 1.0 - object.cloudiness;
+        let adjustedNightSky = nightSky * downFade * cloudinessFade;
         let atmosphereColor = drawSkyAndHorizonFog( direction, object.cameraPosition, vSunDirection, adjustedNightSky );
         output.color = vec4f( atmosphereColor, 1.0 );
         return output;
@@ -93,8 +94,9 @@ fn fs(
 
     // Below-horizon color: evaluate the atmosphere at a horizon-clamped direction
     // so the color exactly matches what's at the horizon edge (no palette mismatch).
+    // Stars fade with cloud coverage.
     let horizonDir = normalize(vec3f(direction.x, max(0.001, direction.y), direction.z));
-    let horizonNightSky = sampleNightSky(horizonDir) * starVisibility;
+    let horizonNightSky = sampleNightSky(horizonDir) * starVisibility * (1.0 - object.cloudiness);
     let horizonFog = drawSkyAndHorizonFog(horizonDir, object.cameraPosition, vSunDirection, horizonNightSky);
 
     // Below clouds — original hemisphere masking
@@ -103,7 +105,7 @@ fn fs(
 
     // Horizon transition band: blend between below-horizon color and atmosphere above
     if ( hemisphereMask < 1 && hemisphereMask > 0.0 ) {
-        let nightSky: vec3f = sampleNightSky(direction);
+        let nightSky: vec3f = sampleNightSky(direction) * (1.0 - object.cloudiness);
         let atmosphereColor = drawSkyAndHorizonFog( direction, object.cameraPosition, vSunDirection, nightSky );
         output.color = vec4f( mix( horizonFog, atmosphereColor, hemisphereMask), 1.0 );
         return output;
@@ -115,7 +117,7 @@ fn fs(
     }
     // Above horizon: full atmosphere
     else {
-        let nightSky: vec3f = sampleNightSky(direction);
+        let nightSky: vec3f = sampleNightSky(direction) * (1.0 - object.cloudiness);
         let atmosphereColor = drawSkyAndHorizonFog( direction, object.cameraPosition, vSunDirection, nightSky );
         output.color = vec4f( atmosphereColor, 1.0 );
         return output;

--- a/packages/rewild-renderer/lib/shaders/sky/skyGradient.wgsl
+++ b/packages/rewild-renderer/lib/shaders/sky/skyGradient.wgsl
@@ -124,11 +124,8 @@ fn fs(
 
 fn drawSkyAndHorizonFog(dir: vec3f, org: vec3f, vSunDirection: vec3f, nightSky: vec3f ) -> vec3f {
     let mu = dot(vSunDirection, dir);
-    var color = getAtmosphereColor(vSunDirection, dir, mu, nightSky * 10.0);
+    var color = getAtmosphereColor(vSunDirection, dir, mu, nightSky);
     color = getFogColor( dir, org, vSunDirection, color.rgb );
-
-    // Adjust exposure
-    var colorAdjustedExposure = vec3f( 1.0 - exp(-color / 8.6));
-    return colorAdjustedExposure;
+    return color;
 }
 

--- a/packages/rewild-renderer/lib/shaders/sky/starfield.wgsl
+++ b/packages/rewild-renderer/lib/shaders/sky/starfield.wgsl
@@ -67,9 +67,13 @@ struct VertexOutput {
   let uv = fragCoord.xy / uniforms.faceSize;
   let dir = getCubeDirection(uniforms.faceIndex, uv);
 
-  // Stars (noise-based) — boosted slightly to compensate for removed pixel-perfect stars
-  var starIntensity = mix(-1.2, 2.0, proceduralNoise3D(500.0 * dir) + 0.10 * proceduralNoise3D(2.0 * dir));
-  starIntensity = clamp(starIntensity, 0.0, 1.0);
+  // Stars (noise-based) — HDR: power curve concentrates intensity at noise peaks.
+  // Bright stars store values > 1 in rgba16float; dim stars → 0. No clamp.
+  // pow(4)*300: noise peaks ≈ 0.45 → ~1 HDR (faint), ≈ 0.50 → ~8 HDR (blooms),
+  // ≈ 0.55 → ~21 HDR (bright halo). Most sky stays at 0; only the top few percent
+  // of noise peaks produce visible stars.
+  var starIntensity = max(0.0, mix(-1.2, 2.0, proceduralNoise3D(500.0 * dir) + 0.10 * proceduralNoise3D(2.0 * dir)));
+  starIntensity = pow(starIntensity, 4.0) * 300.0;
   let starColor = vec3f(
     0.7 + 0.3 * proceduralNoise3D(100.0 * dir),
     0.7 + 0.3 * proceduralNoise3D(103.0 * dir),
@@ -84,7 +88,9 @@ struct VertexOutput {
   galaxyCenter = galaxyCenter * galaxyCenter;
   let galaxyIntensity = galaxyPlane * galaxyCenter;
   let galaxyColor = vec3f(0.5, 0.5, 1.0);
-  let galaxy = 0.8 * galaxyIntensity * galaxyColor;
+  // 8.0 (was 0.8) restores the 10× amplification that used to live in skyGradient.wgsl
+  // so the galaxy stores genuine HDR values in the rgba16float cubemap.
+  let galaxy = 8.0 * galaxyIntensity * galaxyColor;
 
   // Dust
   var d = 0.0;

--- a/packages/rewild-renderer/lib/shaders/sky/starfield.wgsl
+++ b/packages/rewild-renderer/lib/shaders/sky/starfield.wgsl
@@ -4,6 +4,13 @@
 const PI: f32 = 3.141592653589793;
 const GALAXY_NORMAL = vec3f(0.577, 0.577, 0.577);
 const GALAXY_CENTER_DIR = vec3f(-0.707, 0, 0.707);
+// Additional nebula clouds at different locations
+const NEBULA2_NORMAL = vec3f(-0.707, 0.0, -0.707);
+const NEBULA2_CENTER_DIR = vec3f(0.5, 0.5, 0.5);
+const NEBULA3_NORMAL = vec3f(0.0, 0.707, 0.707);
+const NEBULA3_CENTER_DIR = vec3f(0.707, 0.707, 0.0);
+const NEBULA4_NORMAL = vec3f(0.707, -0.707, 0.0);
+const NEBULA4_CENTER_DIR = vec3f(-0.5, -0.5, 0.707);
 
 struct NightSkyUniforms {
   faceIndex: u32,
@@ -69,11 +76,11 @@ struct VertexOutput {
 
   // Stars (noise-based) — HDR: power curve concentrates intensity at noise peaks.
   // Bright stars store values > 1 in rgba16float; dim stars → 0. No clamp.
-  // pow(4)*300: noise peaks ≈ 0.45 → ~1 HDR (faint), ≈ 0.50 → ~8 HDR (blooms),
-  // ≈ 0.55 → ~21 HDR (bright halo). Most sky stays at 0; only the top few percent
-  // of noise peaks produce visible stars.
+  // pow(4)*900: noise peaks ≈ 0.45 → ~6 HDR, ≈ 0.50 → ~56 HDR (bright glow),
+  // ≈ 0.55 → ~126 HDR (prominent halo). Most sky stays at 0; only the top few percent
+  // of noise peaks produce visible stars. 3x multiplier from 300 enables selective bloom.
   var starIntensity = max(0.0, mix(-1.2, 2.0, proceduralNoise3D(500.0 * dir) + 0.10 * proceduralNoise3D(2.0 * dir)));
-  starIntensity = pow(starIntensity, 4.0) * 300.0;
+  starIntensity = pow(starIntensity, 4.0) * 900.0;
   let starColor = vec3f(
     0.7 + 0.3 * proceduralNoise3D(100.0 * dir),
     0.7 + 0.3 * proceduralNoise3D(103.0 * dir),
@@ -81,26 +88,71 @@ struct VertexOutput {
   );
   let stars = starIntensity * starColor;
 
-  // Galaxy
+  // Main galaxy: Milky Way-like structure with noise-based swirls and color variation
   var galaxyPlane = 8.0 * dot(GALAXY_NORMAL, dir);
   galaxyPlane = 1.0 / (galaxyPlane * galaxyPlane + 1.0);
   var galaxyCenter = dot(GALAXY_CENTER_DIR, dir) * 0.5 + 0.5;
   galaxyCenter = galaxyCenter * galaxyCenter;
-  let galaxyIntensity = galaxyPlane * galaxyCenter;
-  let galaxyColor = vec3f(0.5, 0.5, 1.0);
-  // 8.0 (was 0.8) restores the 10× amplification that used to live in skyGradient.wgsl
-  // so the galaxy stores genuine HDR values in the rgba16float cubemap.
-  let galaxy = 8.0 * galaxyIntensity * galaxyColor;
 
-  // Dust
+  // Add swirling detail with multi-octave noise
+  let swirl = (proceduralNoise3D(5.0 * dir) + 0.5 * proceduralNoise3D(15.0 * dir)) * 0.75;
+  let galaxyDetail = galaxyPlane * galaxyCenter * (0.6 + 0.4 * swirl);
+
+  // Color varies from blue nebula to orange/red dust
+  let nebulaBlue = proceduralNoise3D(3.0 * dir);
+  let dustOrange = proceduralNoise3D(7.0 * dir);
+  let galaxyColor = mix(
+    vec3f(0.3, 0.4, 0.8),  // Blue nebula
+    vec3f(0.9, 0.5, 0.2),  // Orange dust
+    0.5 + 0.5 * (nebulaBlue + dustOrange) * 0.5
+  );
+  let galaxy = 10.0 * galaxyDetail * galaxyColor;
+
+  // Secondary nebula: purple/blue
+  var nebula2Plane = 6.0 * dot(NEBULA2_NORMAL, dir);
+  nebula2Plane = 1.0 / (nebula2Plane * nebula2Plane + 1.0);
+  var nebula2Center = dot(NEBULA2_CENTER_DIR, dir) * 0.5 + 0.5;
+  nebula2Center = nebula2Center * nebula2Center;
+  let nebula2Swirl = proceduralNoise3D(8.0 * dir) * 0.8;
+  let nebula2Intensity = nebula2Plane * nebula2Center * (0.4 + 0.6 * nebula2Swirl);
+  let nebula2Color = mix(vec3f(0.3, 0.2, 0.7), vec3f(0.5, 0.3, 0.6), 0.5 + 0.5 * proceduralNoise3D(6.0 * dir));
+  let nebula2 = 5.0 * nebula2Intensity * nebula2Color;
+
+  // Tertiary nebula: cyan/teal
+  var nebula3Plane = 5.0 * dot(NEBULA3_NORMAL, dir);
+  nebula3Plane = 1.0 / (nebula3Plane * nebula3Plane + 1.0);
+  var nebula3Center = dot(NEBULA3_CENTER_DIR, dir) * 0.5 + 0.5;
+  nebula3Center = nebula3Center * nebula3Center;
+  let nebula3Swirl = proceduralNoise3D(7.0 * dir) * 0.7;
+  let nebula3Intensity = nebula3Plane * nebula3Center * (0.3 + 0.7 * nebula3Swirl);
+  let nebula3Color = mix(vec3f(0.2, 0.6, 0.8), vec3f(0.3, 0.5, 0.7), 0.5 + 0.5 * proceduralNoise3D(9.0 * dir));
+  let nebula3 = 4.5 * nebula3Intensity * nebula3Color;
+
+  // Quaternary nebula: faint blue/magenta
+  var nebula4Plane = 5.5 * dot(NEBULA4_NORMAL, dir);
+  nebula4Plane = 1.0 / (nebula4Plane * nebula4Plane + 1.0);
+  var nebula4Center = dot(NEBULA4_CENTER_DIR, dir) * 0.5 + 0.5;
+  nebula4Center = nebula4Center * nebula4Center;
+  let nebula4Swirl = proceduralNoise3D(9.0 * dir) * 0.6;
+  let nebula4Intensity = nebula4Plane * nebula4Center * (0.2 + 0.8 * nebula4Swirl);
+  let nebula4Color = mix(vec3f(0.4, 0.1, 0.6), vec3f(0.3, 0.4, 0.8), 0.5 + 0.5 * proceduralNoise3D(5.0 * dir));
+  let nebula4 = 3.5 * nebula4Intensity * nebula4Color;
+
+  // Dust: cosmic dust clouds that darken regions (extinction)
   var d = 0.0;
   d += 1.00 * proceduralNoise3D(10.0 * dir);
   d += 0.50 * proceduralNoise3D(20.0 * dir);
   d += 0.25 * proceduralNoise3D(100.0 * dir);
   d += 0.20 * proceduralNoise3D(200.0 * dir);
-  let dustColor = vec3f(0.5, 0.4, 0.3);
-  let dust = vec3f(1.0 - (d * 0.6 + 1.2) * galaxyPlane * galaxyCenter) + dustColor;
 
-  let color = stars + galaxy * dust;
+  // Subtle dust extinction: mostly preserves nebula colors, slight reddening
+  let dustFactor = 1.0 - clamp(d * 0.25, 0.0, 0.4);
+  let dustTint = mix(vec3f(1.0), vec3f(1.0, 0.85, 0.8), clamp(d * 0.15, 0.0, 1.0));
+
+  // Combine all nebulae with dust attenuation and tint
+  let allNebulae = galaxy + nebula2 + nebula3 + nebula4;
+  let nebulaeWithDust = allNebulae * (dustFactor * dustTint);
+  let color = stars + nebulaeWithDust;
+
   return vec4f(color, 1.0);
 }


### PR DESCRIPTION
## Summary

Unified HDR sky rendering pipeline with single ACES tonemap pass and dramatically improved night sky.

**Major changes:**
- **Single ACES pass**: Replaced split tonemapping (exp curve for sky, ACES for clouds) with unified tonemapping across the entire scene (sky + clouds + bloom)
- **HDR starfield**: Stars now render as genuine HDR values (up to 126 HDR for bright stars) instead of LDR, enabling proper bloom
- **Multi-nebula night sky**: Added 4 procedurally-generated nebula clouds with swirling detail, color variation (blue/cyan/purple), and cosmic dust extinction
- **Enhanced bloom**: Stars now bloom with tuned HDR_SCALE (0.05) and brightened star multiplier (900x), blooming selectively without oversaturating daytime
- **Improved cloud transparency**: Clouds render with proper alpha blending; thin clouds show sky behind them instead of appearing opaque-white
- **Cloudiness-based effects**: 
  - Stars fade with cloud coverage (invisible at 100% cloudiness)
  - Sky desaturates and shifts to grey under overcast conditions (starts at 50% cloudiness)
- **Atmosphere enhancements**: Sky cap at 60 HDR prevents sun scatter from over-brightening cloud edges

Closes #148